### PR TITLE
add kube inline component

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -6,8 +6,51 @@ metadata:
 components:
   - name: outerloop-build
     image:
-      imageName: hellow-world:latest
+      imageName: hello-world:latest
       dockerfile:
         uri: docker/Dockerfile
         buildContext: .
         rootRequired: false
+  - name: outerloop-deploy
+    kubernetes:
+      inlined: |-
+        kind: Deployment
+        apiVersion: apps/v1
+        metadata:
+          name: my-nginx
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: my-nginx
+          template:
+            metadata:
+              labels:
+                app: my-nginx
+            spec:
+              containers:
+                - name: my-nginx
+                  image: hello-world:latest
+                  ports:
+                    - name: http
+                      containerPort: 8080
+                      protocol: TCP
+                  resources:
+                    limits:
+                      memory: "1024Mi"
+                      cpu: "500m"
+commands:
+  - id: build-image
+    apply:
+      component: outerloop-build
+  - id: deployk8s
+    apply:
+      component: outerloop-deploy
+  - id: deploy
+    composite:
+      commands:
+        - build-image
+        - deployk8s
+      group:
+        kind: deploy
+        isDefault: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,1 +1,3 @@
 FROM quay.io/jitesoft/nginx:latest
+
+ENV PORT="8080"


### PR DESCRIPTION
add kube line component to ensure the devfile is a valid outerloop definition for the e2e test. Use port 8080 instead of default 80.
See detailed discussion: https://redhat-internal.slack.com/archives/C02HZRGKDEY/p1680778911884259